### PR TITLE
Add a .gitattributes file to avoid problems with diffs in windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto eol=lf


### PR DESCRIPTION
This is my first pull request ever !

This is the link to this file in the material-ui repo: [link](https://github.com/mui-org/material-ui/blob/master/.gitattributes)

The official doc:
[link](https://docs.github.com/en/github/using-git/configuring-git-to-handle-line-endings#per-repository-settings)

Anyway I just detected other incompatibilities with the Windows system in the package.json file:

* For inline declaration of env variables it would have to use the cross-env package:
`"compile:esm": "cross-env BABEL_ENV=esm npm run compile -- --out-dir dist/esm",`

* And the rsync command is not compatible either.
